### PR TITLE
Apply Pod Security Admission labels on namespace

### DIFF
--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -119,6 +119,11 @@ local objKey(prefix, obj) =
           // non-OCP.
           'openshift.io/node-selector': '',
         },
+        labels+: {
+          'pod-security.kubernetes.io/audit': 'privileged',
+          'pod-security.kubernetes.io/enforce': 'privileged',
+          'pod-security.kubernetes.io/warn': 'privileged',
+        },
       },
     },
   '01_secret': tokenSecret,

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -10,6 +10,14 @@ default:: `syn-cloudscale-cloud-controller-manager`
 
 The namespace in which to deploy this component.
 
+[TIP]
+====
+The component labels the namespace with the Kubernetes Pod Security Admission labels set to `privileged`.
+This ensures that the CCM pods (which use `hostNetwork=true` to avoid issues during cluster bootstrap) are admitted.
+====
+
+NOTE: The component won't emit a manifest for the namespace if this parameter is set to `kube-system`.
+
 == `manifests_version`
 
 [horizontal]

--- a/tests/golden/defaults/cloudscale-cloud-controller-manager/cloudscale-cloud-controller-manager/00_namespace.yaml
+++ b/tests/golden/defaults/cloudscale-cloud-controller-manager/cloudscale-cloud-controller-manager/00_namespace.yaml
@@ -5,4 +5,7 @@ metadata:
     openshift.io/node-selector: ''
   labels:
     name: syn-cloudscale-cloud-controller-manager
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/warn: privileged
   name: syn-cloudscale-cloud-controller-manager

--- a/tests/golden/openshift4/cloudscale-cloud-controller-manager/cloudscale-cloud-controller-manager/00_namespace.yaml
+++ b/tests/golden/openshift4/cloudscale-cloud-controller-manager/cloudscale-cloud-controller-manager/00_namespace.yaml
@@ -5,4 +5,7 @@ metadata:
     openshift.io/node-selector: ''
   labels:
     name: syn-cloudscale-cloud-controller-manager
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/warn: privileged
   name: syn-cloudscale-cloud-controller-manager


### PR DESCRIPTION
We label the namespace with all three Pod Security Admission labels (`audit`, `warn`, `enforce`) set to `privileged` This ensures that the CCM pods (which use `hostNetwork=true` to avoid bootstrap issues) can be scheduled.




## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
